### PR TITLE
Fix bug when element is deleted and inserted again

### DIFF
--- a/timing2.js
+++ b/timing2.js
@@ -151,23 +151,19 @@ confirmBtn.onclick = function() {
 	if ( addFoodText.value !== "" ) {
 		if(currentId === "") {
 			//assign a new id
-			var id = "product"+timerMap.size.toString();
+			var ms = Date.now();
+			var id = "product_"+ ms.toString();
+
 			//create new timer
 			var timer = new Timer(id, addFoodText.value, 60);
 			timer.create(id);
 			//add to the map of timers
 			timerMap.set(id, timer);
 
-			//save timerMap into cookie
-			
     		var timerMapObj = {};
 			for (var [timer_index, timer] of timerMap ){
-
 				timerMapObj[timer_index] = timer;
 			}
-		    var timerMapStr = JSON.stringify(timerMapObj);
-			document.cookie = "savedMap="+timerMapStr;
-			console.log(document.cookie);
 
 		} else {
 			//modify timer


### PR DESCRIPTION
Bug:

* product A is inserted, with id product+sizeof(list) = product0
* product B is inserted, with id product+sizeof(list) = product1
* product A is removed, sizeof(list)=1
* product C is inserted, with id product+sizeof(list) = product1

This causes an id duplication.

Solution: use timestamp to get unique id after each insertion

Related issue: #5 